### PR TITLE
Add Prometheus to the kube deployer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ServiceWeaver/weaver-k8s
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.13.0
+	github.com/ServiceWeaver/weaver v0.14.0
 	github.com/docker/cli v24.0.2+incompatible
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/DataDog/hyperloglog v0.0.0-20220214164406-974598347557 h1:t+/ZxFkPEVJ
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.10.0-rc.8 h1:YSZVvlIIDD1UxQpJp0h+dnpLUw+TrY0cx8obKsp3bek=
-github.com/ServiceWeaver/weaver v0.13.0 h1:ZRLXRxIUNhVjZMTz+4J1hlJkq7+eu8a2aV6t3k8THkU=
-github.com/ServiceWeaver/weaver v0.13.0/go.mod h1:zvziH3h+Blab1yppwDsmaZks2Zd5C3/YmSNs6LCODSY=
+github.com/ServiceWeaver/weaver v0.14.0 h1:UA9Npo7yLdOZkUaMm1ydfpsgrqS8Vx60Qiko6XVa/oE=
+github.com/ServiceWeaver/weaver v0.14.0/go.mod h1:zvziH3h+Blab1yppwDsmaZks2Zd5C3/YmSNs6LCODSY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed h1:ue9pVfIcP+QMEjfgo/Ez4ZjNZfonGgR6NgjMaJMu1Cg=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/containerd/containerd v1.7.1 h1:k8DbDkSOwt5rgxQ3uCI4WMKIJxIndSCBUaGm5oRn+Go=

--- a/internal/impl/k8s.proto
+++ b/internal/impl/k8s.proto
@@ -34,4 +34,3 @@ message ReplicaSetConfig {
   map<string, Listeners> components_to_start = 3;
   int32 internal_port = 4;
 }
-


### PR DESCRIPTION
With this PR, the kubernetes deployer is launching a prometheus service that is able to manipulate the metrics exported by a running Service Weaver application.

[metrics_demo.webm](https://github.com/ServiceWeaver/weaver-k8s/assets/1679018/602ed3a0-2fb8-4bba-bb1b-d4ea270e0f32)

What this PR adds:
* a config map that holds the configuration needed by Prometheus to scrape the app pods for app metrics
* a deploymend and a service for Prometheus

TODO: We should add more labels to scrape pods for cpu, memory, etc.