### PR TITLE
Dockerfile template: install CA certificates for "go install" to work

### DIFF
--- a/internal/impl/docker.go
+++ b/internal/impl/docker.go
@@ -47,7 +47,7 @@ var dockerfileTmpl = template.Must(template.New("Dockerfile").Parse(`
 FROM ubuntu:rolling
 WORKDIR /weaver/
 RUN apt-get update
-RUN apt-get install -y golang-go{{range .}}
+RUN apt-get install -y golang-go{{range .}} ca-certificates
 RUN GOPATH=/weaver/ go install {{.}}{{end}}
 RUN if [ "$(ls -A /weaver/bin)" ]; then cp /weaver/bin/* /weaver/; fi
 COPY . .


### PR DESCRIPTION
Problem: `ubuntu:rolling` image lacks X.509 certificates that are required by the "go install" to function properly. "go install" doesn't seem to use the [fallback CA roots](https://github.com/golang/go/issues/43958) at the moment and fails, resulting in  failure to generate the container image needed to deploy the service.

Solution: install [`ca-certificates` Ubuntu package](https://packages.ubuntu.com/search?keywords=ca-certificates).

Resolves https://github.com/ServiceWeaver/weaver-kube/issues/13.