### PR TITLE
Show "successfully generated" message as green text, not red

### DIFF
--- a/internal/impl/kube.go
+++ b/internal/impl/kube.go
@@ -175,7 +175,7 @@ func GenerateKubeDeployment(image string, dep *protos.Deployment, cfg *KubeConfi
 	if _, err := f.Write(generated); err != nil {
 		return fmt.Errorf("unable to write the kube deployment info: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, redText(), fmt.Sprintf("kube deployment information successfully generated in %s", yamlFile))
+	fmt.Fprintf(os.Stderr, greenText(), fmt.Sprintf("kube deployment information successfully generated in %s", yamlFile))
 	return nil
 }
 


### PR DESCRIPTION
Problem: `kube deployment information successfully generated in *.yaml` message at the end of `weaver kube deploy` is shown in red color, but red color normally signifies an error.

Solution: render this message using the green color.