### PR TITLE
Automatically infer Docker Hub username.

### DIFF
--- a/cmd/weaver-kube/deploy.go
+++ b/cmd/weaver-kube/deploy.go
@@ -37,12 +37,26 @@ const (
 )
 
 var (
-	deployCmd = tool.Command{
+	deployFlags       = flag.NewFlagSet("deploy", flag.ContinueOnError)
+	dockerhubUsername = deployFlags.String("username", "", "Docker Hub username")
+	deployCmd         = tool.Command{
 		Name:        "deploy",
 		Description: "Deploy a Service Weaver app",
-		Help:        "Usage:\n  weaver kube deploy <configfile>",
-		Flags:       flag.NewFlagSet("deploy", flag.ContinueOnError),
-		Fn:          deploy,
+		Help: `Usage:
+  weaver kube deploy [--username=<username>] <configfile>
+
+Flags:
+  -h, --help	Print this help message.
+  --username	Docker Hub username.
+
+Docker Hub:
+  "weaver kube deploy" builds and uploads a container to Docker Hub. By
+  default, "weaver kube deploy" uses the Docker Hub username authenticated with
+  "docker login". You can also provide a username explicitly using the
+  --username flag.
+`,
+		Flags: deployFlags,
+		Fn:    deploy,
 	}
 )
 
@@ -53,6 +67,16 @@ func deploy(ctx context.Context, args []string) error {
 	}
 	if len(args) > 1 {
 		return fmt.Errorf("too many arguments")
+	}
+
+	// Get Docker Hub username.
+	username := *dockerhubUsername
+	if username == "" {
+		var err error
+		username, err = impl.DockerHubUsername()
+		if err != nil {
+			return fmt.Errorf("unable to infer Docker Hub username. Please use the --username flag.\n%w", err)
+		}
 	}
 
 	// Load the config file.
@@ -99,7 +123,7 @@ func deploy(ctx context.Context, args []string) error {
 	}
 
 	// Build the docker image for the deployment, and upload it to docker hub.
-	image, err := impl.BuildAndUploadDockerImage(ctx, dep)
+	image, err := impl.BuildAndUploadDockerImage(ctx, dep, username)
 	if err != nil {
 		return err
 	}

--- a/cmd/weaver-kube/deploy.go
+++ b/cmd/weaver-kube/deploy.go
@@ -37,25 +37,20 @@ const (
 )
 
 var (
-	deployFlags       = flag.NewFlagSet("deploy", flag.ContinueOnError)
-	dockerhubUsername = deployFlags.String("username", "", "Docker Hub username")
-	deployCmd         = tool.Command{
+	deployCmd = tool.Command{
 		Name:        "deploy",
 		Description: "Deploy a Service Weaver app",
 		Help: `Usage:
-  weaver kube deploy [--username=<username>] <configfile>
+  weaver kube deploy <configfile>
 
 Flags:
   -h, --help	Print this help message.
-  --username	Docker Hub username.
 
 Docker Hub:
-  "weaver kube deploy" builds and uploads a container to Docker Hub. By
-  default, "weaver kube deploy" uses the Docker Hub username authenticated with
-  "docker login". You can also provide a username explicitly using the
-  --username flag.
+  "weaver kube deploy" builds and uploads a container to Docker Hub. "weaver
+  kube deploy" uses the Docker Hub username authenticated with "docker login".
 `,
-		Flags: deployFlags,
+		Flags: flag.NewFlagSet("deploy", flag.ContinueOnError),
 		Fn:    deploy,
 	}
 )
@@ -70,13 +65,9 @@ func deploy(ctx context.Context, args []string) error {
 	}
 
 	// Get Docker Hub username.
-	username := *dockerhubUsername
-	if username == "" {
-		var err error
-		username, err = impl.DockerHubUsername()
-		if err != nil {
-			return fmt.Errorf("unable to infer Docker Hub username. Please use the --username flag.\n%w", err)
-		}
+	username, err := impl.DockerHubUsername()
+	if err != nil {
+		return fmt.Errorf("unable to infer Docker Hub username: %w", err)
 	}
 
 	// Load the config file.


### PR DESCRIPTION
Before this PR, you had to pass `weaver kube deploy` your Docker Hub username using the `SERVICEWEAVER_DOCKER_HUB_ID` environment variable. This PR does a couple of things:

1. It replaces the environment variable with a flag, `--username`.
2. It automatically infers the username from the output of `docker info`. This username is established when you run `docker login` and is the username used when you `docker push`.
3. It expands the help message of `docker kube deploy` to explain the use of Docker Hub usernames.