### PR TITLE
Added support for arbitrary container registry.

### DIFF
--- a/cmd/weaver-kube/deploy.go
+++ b/cmd/weaver-kube/deploy.go
@@ -55,7 +55,7 @@ Container Image Names:
       binary = "./foo"
 
       [kube]
-      registry = "docker.io/my_docker_hub_username/foo"
+      image = "docker.io/my_docker_hub_username/foo"
 
   Using this config file, "weaver kube deploy" will build a container called
   "docker.io/my_docker_hub_username/foo" and upload it to Docker Hub. The

--- a/cmd/weaver-kube/deploy.go
+++ b/cmd/weaver-kube/deploy.go
@@ -40,9 +40,37 @@ var (
 	deployCmd = tool.Command{
 		Name:        "deploy",
 		Description: "Deploy a Service Weaver app",
-		Help:        "Usage:\n  weaver kube deploy <configfile>",
-		Flags:       flag.NewFlagSet("deploy", flag.ContinueOnError),
-		Fn:          deploy,
+		Help: `Usage:
+  weaver kube deploy <configfile>
+
+Flags:
+  -h, --help	Print this help message.
+
+Container Registries:
+  "weaver kube deploy" builds and uploads a container image to a container
+  registry. You need to specify which container registry using the "registry"
+  field inside the "kube" section of the config file. For example, consider the
+  following config file:
+
+      [serviceweaver]
+      binary = "./foo"
+
+      [kube]
+      registry = "my_docker_hub_username"
+
+  Using this config file, "weaver kube deploy" will upload a container image to
+  Docker Hub by running "docker push my_docker_hub_username/IMAGE:TAG". The
+  format of the "registry" field depends on the registry being used. Some
+  examples:
+
+      - Docker Hub: USERNAME
+      - Google Artifact Registry: LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY
+      - GitHub Container Registry: ghcr.io/NAMESPACE
+
+  Note that for "weaver kube deploy" to work correctly, you must be
+  authenticated with the provided registry (e.g., by running "docker login".)`,
+		Flags: flag.NewFlagSet("deploy", flag.ContinueOnError),
+		Fn:    deploy,
 	}
 )
 
@@ -76,6 +104,10 @@ func deploy(ctx context.Context, args []string) error {
 	if err := runtime.ParseConfigSection(configKey, shortConfigKey, app.Sections, config); err != nil {
 		return fmt.Errorf("parse kube config: %w", err)
 	}
+	if config.Registry == "" {
+		// TODO(mwhittaker): Try to infer a sane default registry to use.
+		return fmt.Errorf("No Registry provided in config files. See `weaver kube deploy --help` for details")
+	}
 	binListeners, err := bin.ReadListeners(app.Binary)
 	if err != nil {
 		return fmt.Errorf("cannot read listeners from binary %s: %w", app.Binary, err)
@@ -99,7 +131,7 @@ func deploy(ctx context.Context, args []string) error {
 	}
 
 	// Build the docker image for the deployment, and upload it to docker hub.
-	image, err := impl.BuildAndUploadDockerImage(ctx, dep)
+	image, err := impl.BuildAndUploadDockerImage(ctx, dep, config.Registry)
 	if err != nil {
 		return err
 	}

--- a/internal/impl/docker.go
+++ b/internal/impl/docker.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"text/template"
@@ -52,9 +51,9 @@ type imageSpecs struct {
 }
 
 // BuildAndUploadDockerImage builds a docker image and upload it to docker hub.
-func BuildAndUploadDockerImage(ctx context.Context, dep *protos.Deployment, registry string) (string, error) {
+func BuildAndUploadDockerImage(ctx context.Context, dep *protos.Deployment, image string) (string, error) {
 	// Create the docker image specifications.
-	specs, err := buildImageSpecs(dep, registry)
+	specs, err := buildImageSpecs(dep, image)
 	if err != nil {
 		return "", fmt.Errorf("unable to build image specs: %w", err)
 	}
@@ -134,7 +133,7 @@ func uploadImage(ctx context.Context, appImage string) error {
 }
 
 // buildImageSpecs build the docker image specs for an app deployment.
-func buildImageSpecs(dep *protos.Deployment, registry string) (*imageSpecs, error) {
+func buildImageSpecs(dep *protos.Deployment, image string) (*imageSpecs, error) {
 	// Copy the app binary and the tool that starts the babysitter into the image.
 	files := []string{dep.App.Binary}
 	var goInstall []string
@@ -150,7 +149,7 @@ func buildImageSpecs(dep *protos.Deployment, registry string) (*imageSpecs, erro
 		goInstall = append(goInstall, "github.com/ServiceWeaver/weaver-kube/cmd/weaver-kube@latest")
 	}
 	return &imageSpecs{
-		name:      path.Join(registry, fmt.Sprintf("weaver-%s:%s", dep.App.Name, dep.Id[:8])),
+		name:      fmt.Sprintf("%s:%s", image, dep.Id[:8]),
 		files:     files,
 		goInstall: goInstall,
 	}, nil

--- a/internal/impl/kube.go
+++ b/internal/impl/kube.go
@@ -126,17 +126,20 @@ type ListenerOptions struct {
 // KubeConfig stores the configuration information for one execution of a
 // Service Weaver application deployed using the Kube deployer.
 type KubeConfig struct {
-	// Registry is the container registry to which container images are
-	// uploaded. Specifically, the image name is prefixed by Registry and then
-	// `docker push`ed. For example, if Registry is "foo", then `weaver kube
-	// deploy` uploads an image using `docker push foo/IMAGE:TAG`.
+	// Image is the name of the container image that "weaver kube deploy"
+	// builds and uploads. For example, if Image is "docker.io/alanturing/foo",
+	// then "weaver kube deploy" will build a container called
+	// "docker.io/alanturing/foo" and upload it to Docker Hub.
 	//
-	// The format of Registry depends on the registry being used. For example:
+	// The format of Image depends on the registry being used. For example:
 	//
-	// - Docker Hub: USERNAME
-	// - Google Artifact Registry: LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY
-	// - GitHub Container Registry: ghcr.io/NAMESPACE
-	Registry string
+	// - Docker Hub: USERNAME/NAME or docker.io/USERNAME/NAME
+	// - Google Artifact Registry: LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY/NAME
+	// - GitHub Container Registry: ghcr.io/NAMESPACE/NAME
+	//
+	// Note that "weaver kube deploy" will automatically append a unique tag to
+	// Image, so Image should not already contain a tag.
+	Image string
 
 	// Options for the application listeners, keyed by listener name.
 	// If a listener isn't specified in the map, default options will be used.

--- a/internal/impl/kube.go
+++ b/internal/impl/kube.go
@@ -123,9 +123,21 @@ type ListenerOptions struct {
 	Public bool
 }
 
-// kubeConfig stores the configuration information for one execution of a
+// KubeConfig stores the configuration information for one execution of a
 // Service Weaver application deployed using the Kube deployer.
 type KubeConfig struct {
+	// Registry is the container registry to which container images are
+	// uploaded. Specifically, the image name is prefixed by Registry and then
+	// `docker push`ed. For example, if Registry is "foo", then `weaver kube
+	// deploy` uploads an image using `docker push foo/IMAGE:TAG`.
+	//
+	// The format of Registry depends on the registry being used. For example:
+	//
+	// - Docker Hub: USERNAME
+	// - Google Artifact Registry: LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY
+	// - GitHub Container Registry: ghcr.io/NAMESPACE
+	Registry string
+
 	// Options for the application listeners, keyed by listener name.
 	// If a listener isn't specified in the map, default options will be used.
 	Listeners map[string]*ListenerOptions


### PR DESCRIPTION
Recall that `weaver kube deploy` needs to build and upload a container image to some registry. Before this PR, `weaver kube deploy` uploaded images to Docker Hub. In PR #21, @giautm suggested we add support for arbitrary container registries. This PR implements his idea.

Specifically, the user provides an `image` field inside the `"kube"` section of the config file. For example, given the following config file:

```toml
[serviceweaver]
binary = "./foo"

[kube]
registry = "my_username/foo"
```

`weaver kube deploy` will run `docker push my_username/foo:TAG`. The user can provide any registry that is compatible with `docker push`. Some examples:

- Docker Hub: `USERNAME/NAME`
- Google Artifact Registry: `LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY/NAME`
- GitHub Container Registry: `ghcr.io/NAMESPACE/NAME`

Fixes #11.