### PR TITLE
By default, see metrics for the last 1h

### DIFF
--- a/internal/impl/dashboard.txt
+++ b/internal/impl/dashboard.txt
@@ -489,7 +489,7 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
Before this PR, when you open the Grafana dashboard, you see the metrics for the last 6 hours. This PR changed the default value to 1h for better visibility.