### PR TITLE
Remove duplicate imports

### DIFF
--- a/cmd/weaver-kube/deploy.go
+++ b/cmd/weaver-kube/deploy.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/ServiceWeaver/weaver-kube/internal/impl"
-	"github.com/ServiceWeaver/weaver/runtime"
 	swruntime "github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/bin"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
@@ -106,7 +105,7 @@ func deploy(ctx context.Context, args []string) error {
 
 	// Parse and validate the kube section of the config.
 	config := &impl.KubeConfig{}
-	if err := runtime.ParseConfigSection(configKey, shortConfigKey, app.Sections, config); err != nil {
+	if err := swruntime.ParseConfigSection(configKey, shortConfigKey, app.Sections, config); err != nil {
 		return fmt.Errorf("parse kube config: %w", err)
 	}
 	if config.Image == "" {

--- a/internal/impl/observability.go
+++ b/internal/impl/observability.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/apps/v1"
 	_ "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -252,9 +251,9 @@ func generateConfigsToExportTraces(dep *protos.Deployment, cfg *KubeConfig) ([]b
 					},
 				},
 			},
-			Strategy: v1.DeploymentStrategy{
+			Strategy: appsv1.DeploymentStrategy{
 				Type:          "RollingUpdate",
-				RollingUpdate: &v1.RollingUpdateDeployment{},
+				RollingUpdate: &appsv1.RollingUpdateDeployment{},
 			},
 		},
 	}
@@ -525,9 +524,9 @@ func generatePrometheusServiceConfigs(dep *protos.Deployment, cfg *KubeConfig) (
 					},
 				},
 			},
-			Strategy: v1.DeploymentStrategy{
+			Strategy: appsv1.DeploymentStrategy{
 				Type:          "RollingUpdate",
-				RollingUpdate: &v1.RollingUpdateDeployment{},
+				RollingUpdate: &appsv1.RollingUpdateDeployment{},
 			},
 		},
 	}
@@ -923,9 +922,9 @@ func generateLokiServiceConfigs(dep *protos.Deployment, cfg *KubeConfig) ([]byte
 					},
 				},
 			},
-			Strategy: v1.DeploymentStrategy{
+			Strategy: appsv1.DeploymentStrategy{
 				Type:          "RollingUpdate",
-				RollingUpdate: &v1.RollingUpdateDeployment{},
+				RollingUpdate: &appsv1.RollingUpdateDeployment{},
 			},
 		},
 	}
@@ -1091,9 +1090,9 @@ func generatePromtailAgentConfigs(dep *protos.Deployment, cfg *KubeConfig) ([]by
 					},
 				},
 			},
-			UpdateStrategy: v1.DaemonSetUpdateStrategy{
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 				Type:          "RollingUpdate",
-				RollingUpdate: &v1.RollingUpdateDaemonSet{},
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{},
 			},
 		},
 	}
@@ -1438,9 +1437,9 @@ func generateGrafanaServiceConfigs(dep *protos.Deployment, cfg *KubeConfig) ([]b
 					},
 				},
 			},
-			Strategy: v1.DeploymentStrategy{
+			Strategy: appsv1.DeploymentStrategy{
 				Type:          "RollingUpdate",
-				RollingUpdate: &v1.RollingUpdateDeployment{},
+				RollingUpdate: &appsv1.RollingUpdateDeployment{},
 			},
 		},
 	}


### PR DESCRIPTION
Remove imports that import an already-imported package with a different alias. Also, change the import alias of "k8s.io/api/autoscaling/v2" from `v2` to `autoscalingv2` for consistency.