### PR TITLE
Publish a container to a minikube registry, instead of GitHub registry.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ name: Integration Test
 
 env:
     CONFIG_FILE: deploy.toml
-    IMAGE_NAME: $(echo "ghcr.io/${{ github.repository }}/echo" | tr '[:upper:]' '[:lower:]')
+    IMAGE_NAME: 192.168.50.2:5000/echo
     WAIT_TIMEOUT: "5m"
 
 on:
@@ -29,34 +29,39 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: "Re-configure docker"
+      # NOTE: This step allows the weaver-kube tool to push the container images
+      # to the minikube cluster repository.
+      run: |
+        echo '{"insecure-registries" : ["192.168.50.2:5000"]}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl daemon-reload
+        sudo systemctl restart docker
+
     - name: Check out the repository
       uses: actions/checkout@v3
-
+    
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: 'stable'
         cache: true
-
+ 
     - name: Setup kubectl.
       uses: azure/setup-kubectl@v3
 
     - name: Setup minikube
       uses: medyagh/setup-minikube@master
-
-    - name: Login into Github Container Registry
-      uses: docker/login-action@v2
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        start-args: '--subnet 192.168.50.0/24'
+        addons: registry
+        insecure-registry: '192.168.50.0/24'
 
     - name: Install weaver-kube
       run: cd cmd/weaver-kube; go build .
 
     - name: Build echo example.
       run: cd examples/echo; go build .
-
+    
     - name: Generate app config file
       run: |
         CONFIG=$(cat << EOF
@@ -72,7 +77,7 @@ jobs:
 
     - name: Build the docker image and push
       run: ./cmd/weaver-kube/weaver-kube deploy --runInDevMode ${{ env.CONFIG_FILE }}
-
+    
     - name: Deploy the application
       run: kubectl apply -f ./kube_*.yaml
 
@@ -91,5 +96,5 @@ jobs:
         kubectl get all
         kubectl describe pod
         kubectl logs -l appName=echo
-
-
+  
+  

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cmd/weaver-kube/weaver-kube
+examples/echo/echo

--- a/internal/impl/docker.go
+++ b/internal/impl/docker.go
@@ -36,7 +36,7 @@ import (
 // runtime errors (e.g., glibc).
 var dockerfileTmpl = template.Must(template.New("Dockerfile").Parse(`
 {{if . }}
-FROM golang:1.20-bullseye as builder
+FROM golang:bullseye as builder
 RUN echo ""{{range .}} && go install {{.}}{{end}}
 {{end}}
 FROM ubuntu:rolling


### PR DESCRIPTION
This solves the permissions issues when running integratino tests from non-ServiceWeaver org repositories (i.e., by external users).