### PR TITLE
Small changes to support the Ardan Labs workflow.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ name: Integration Test
 
 env:
     CONFIG_FILE: deploy.toml
-    IMAGE_NAME: 192.168.50.2:5000/echo
+    REPO_URL: 192.168.50.2:5000
     WAIT_TIMEOUT: "5m"
 
 on:
@@ -69,17 +69,20 @@ jobs:
         binary = "./examples/echo/echo"
 
         [kube]
-        image = "${{ env.IMAGE_NAME }}"
+        repo = "${{ env.REPO_URL }}"
         listeners.echo = {public = true}
         EOF
         )
         echo "$CONFIG" > ${{ env.CONFIG_FILE }}
 
     - name: Build the docker image and push
-      run: ./cmd/weaver-kube/weaver-kube deploy --runInDevMode ${{ env.CONFIG_FILE }}
+      run: |
+        WEAVER_YAML=$(./cmd/weaver-kube/weaver-kube deploy --runInDevMode ${{ env.CONFIG_FILE }})
+        echo "Generated YAML file:" $WEAVER_YAML
+        echo "WEAVER_YAML=$WEAVER_YAML" >> $GITHUB_ENV
     
     - name: Deploy the application
-      run: kubectl apply -f ./kube_*.yaml
+      run: kubectl apply -f ${{env.WEAVER_YAML}}
 
     - name: Get the name of the echo listener service
       run: |

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,5 +18,5 @@ const (
 	// weaver-kube module version (Major.Minor.Patch).
 	Major = 0
 	Minor = 20
-	Patch = 0
+	Patch = 1
 )


### PR DESCRIPTION
Namely:
  * Allow the container to be built locally, but not pushed to a (remote) repository. The workshop application pushes the container image to the minikube-like cluster via a separate command, which doesn't require hosting the container in a repo.
  * Allow the container local build tag to be specified. The workshop application pushes the container image manually, so it is convenient to be able to specify a fixed tag the container is generated with.
  * Output the generated manifest file path when running weaver-gke deploy, so that scripts can pass that output to `kubectl apply`.
  * Place the manifest files into a temporary directory, as opposed to the current directory. This prevents files being created in the user's application directory, which is likely version controller.