### PR TITLE
Don't read tool version from a file.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Build the docker image and push
       run: |
-        WEAVER_YAML=$(./cmd/weaver-kube/weaver-kube deploy --runInDevMode ${{ env.CONFIG_FILE }})
+        WEAVER_YAML=$(./cmd/weaver-kube/weaver-kube deploy ${{ env.CONFIG_FILE }})
         echo "Generated YAML file:" $WEAVER_YAML
         echo "WEAVER_YAML=$WEAVER_YAML" >> $GITHUB_ENV
     

--- a/cmd/weaver-kube/deploy.go
+++ b/cmd/weaver-kube/deploy.go
@@ -36,9 +36,7 @@ const (
 )
 
 var (
-	flags        = flag.NewFlagSet("deploy", flag.ContinueOnError)
-	runInDevMode = flags.Bool("runInDevMode", false, "Whether deploy in development mode.")
-
+	flags     = flag.NewFlagSet("deploy", flag.ContinueOnError)
 	deployCmd = tool.Command{
 		Name:        "deploy",
 		Description: "Deploy a Service Weaver app",
@@ -141,7 +139,7 @@ func deploy(ctx context.Context, args []string) error {
 	}
 
 	// Build the docker image for the deployment.
-	image, err := impl.BuildAndUploadDockerImage(ctx, dep, config.LocalTag, config.Repo, *runInDevMode)
+	image, err := impl.BuildAndUploadDockerImage(ctx, dep, config.LocalTag, config.Repo)
 	if err != nil {
 		return err
 	}

--- a/cmd/weaver-kube/version.go
+++ b/cmd/weaver-kube/version.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/ServiceWeaver/weaver-kube/internal/version"
+	"github.com/ServiceWeaver/weaver-kube/internal/impl"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
@@ -30,7 +30,11 @@ var versionCmd = tool.Command{
 	Description: "Show weaver kube version",
 	Help:        "Usage:\n  weaver kube version",
 	Fn: func(context.Context, []string) error {
-		fmt.Printf("weaver kube v%d.%d.%d %s/%s\n", version.Major, version.Minor, version.Patch, runtime.GOOS, runtime.GOARCH)
+		version, _, err := impl.ToolVersion()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("weaver kube %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
 		return nil
 	},
 }

--- a/internal/impl/version.go
+++ b/internal/impl/version.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,11 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package version
+package impl
 
-const (
-	// weaver-kube module version (Major.Minor.Patch).
-	Major = 0
-	Minor = 21
-	Patch = 0
+import (
+	"fmt"
+	"runtime/debug"
 )
+
+// ToolVersion returns the version of the running tool binary, along with
+// an indication whether the tool was built manually, i.e., not via go install.
+func ToolVersion() (string, bool, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		// Should never happen.
+		return "", false, fmt.Errorf("tool binary must be built from a module")
+	}
+	dev := info.Main.Version == "(devel)"
+	return info.Main.Version, dev, nil
+}


### PR DESCRIPTION
Instead, rely on the version stored inside the compiled binary. This version is automatically filled by `go install`.

This change will allow us to simply tag the release and not have to also update the version manually.