### PR TITLE
Fixed DNS bug preventing pods from talking.

### DIFF
--- a/internal/impl/kube.go
+++ b/internal/impl/kube.go
@@ -202,7 +202,7 @@ func (r *replicaSet) buildDeployment(cfg *KubeConfig) (*appsv1.Deployment, error
 	} else {
 		matchLabels["depName"] = r.deploymentName()
 	}
-	dnsPolicy := corev1.DNSDefault
+	dnsPolicy := corev1.DNSClusterFirst
 	if cfg.UseHostNetwork {
 		dnsPolicy = corev1.DNSClusterFirstWithHostNet
 	}


### PR DESCRIPTION
@rgrandl pointed out that main components were failing to push traces to jaeger, causing them to crash. I did some debugging and found that the DNS policy we were using was preventing pods from resolving service names. I have no idea why.

This PR fixes the bug by switching to the `ClusterFirst` DNS policy. Quite counterintuitively, `ClusterFirst` is the default policy, not `Default`.