### PR TITLE
Made Deployment, Service, HPA names more legible.

### DIFF
--- a/internal/impl/babysitter.go
+++ b/internal/impl/babysitter.go
@@ -222,7 +222,7 @@ func (b *babysitter) watchPods(ctx context.Context, component string) error {
 
 	// Watch the pods running the requested component.
 	rs := replicaSetName(component, b.cfg.App)
-	name := name{b.cfg.App.Name, rs, b.cfg.DepId[:8]}.DNSLabel()
+	name := deploymentName(b.cfg.App.Name, rs, b.cfg.DepId)
 	opts := metav1.ListOptions{LabelSelector: fmt.Sprintf("depName=%s", name)}
 	watcher, err := b.clientset.CoreV1().Pods(b.cfg.Namespace).Watch(ctx, opts)
 	if err != nil {


### PR DESCRIPTION
This PR makes the Deployment, Service, and HorizontalPodAutoscaler (HPA) names generated by weaver-kube more legible.

Deployment and HorizontalPodAutoscaler names are now of the form:

    $PACKAGE-$COMPONENT-$SHORT_DEPLOYMENT_ID-$HASH

For example, "collatz-even-40627718-0f5e1429". The hash is a hash of the app name, full component name, and full deployment id. It exists to avoid collisions.

Listener names are now of the form `$LISTENER-$SHORT_DEPLOYMENT_ID` (e.g., "collatz-40627718").

Here's the Kuberentes YAML generated for the collatz app before and after this PR:

```diff
47c47
<   name: collatz-github-com-serviceweaver-weaver-main-40627718-342fb672
---
>   name: weaver-main-40627718-2de78911
52c52
<       depName: collatz-github-com-serviceweaver-weaver-main-40627718-342fb672
---
>       depName: weaver-main-40627718-2de78911
59c59
<         depName: collatz-github-com-serviceweaver-weaver-main-40627718-342fb672
---
>         depName: weaver-main-40627718-2de78911
95c95
<   name: collatz-hpa-com-serviceweaver-weaver-main-40627718-9924cbfc
---
>   name: weaver-main-40627718-2de78911
110c110
<     name: collatz-github-com-serviceweaver-weaver-main-40627718-342fb672
---
>     name: weaver-main-40627718-2de78911
125c125
<   name: collatz-lis-collatz-40627718-d5953558
---
>   name: collatz-40627718
133c133
<     depName: collatz-github-com-serviceweaver-weaver-main-40627718-342fb672
---
>     depName: weaver-main-40627718-2de78911
147c147
<   name: collatz-ceweaver-weaver-examples-collatz-even-40627718-ab258ef8
---
>   name: collatz-even-40627718-0f5e1429
152c152
<       depName: collatz-ceweaver-weaver-examples-collatz-even-40627718-ab258ef8
---
>       depName: collatz-even-40627718-0f5e1429
159c159
<         depName: collatz-ceweaver-weaver-examples-collatz-even-40627718-ab258ef8
---
>         depName: collatz-even-40627718-0f5e1429
193c193
<   name: collatz-hpa-weaver-examples-collatz-even-40627718-5d4ed291
---
>   name: collatz-even-40627718-0f5e1429
208c208
<     name: collatz-ceweaver-weaver-examples-collatz-even-40627718-ab258ef8
---
>     name: collatz-even-40627718-0f5e1429
222c222
<   name: collatz-iceweaver-weaver-examples-collatz-odd-40627718-9be825b3
---
>   name: collatz-odd-40627718-0ecfc643
227c227
<       depName: collatz-iceweaver-weaver-examples-collatz-odd-40627718-9be825b3
---
>       depName: collatz-odd-40627718-0ecfc643
234c234
<         depName: collatz-iceweaver-weaver-examples-collatz-odd-40627718-9be825b3
---
>         depName: collatz-odd-40627718-0ecfc643
268c268
<   name: collatz-hpa-r-weaver-examples-collatz-odd-40627718-018acc58
---
>   name: collatz-odd-40627718-0ecfc643
283c283
<     name: collatz-iceweaver-weaver-examples-collatz-odd-40627718-9be825b3
---
>     name: collatz-odd-40627718-0ecfc643
```