### PR TITLE
Improve generated Kubernetes labels.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,13 +39,13 @@ jobs:
 
     - name: Check out the repository
       uses: actions/checkout@v3
-    
+
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: 'stable'
         cache: true
- 
+
     - name: Setup kubectl.
       uses: azure/setup-kubectl@v3
 
@@ -61,7 +61,7 @@ jobs:
 
     - name: Build echo example.
       run: cd examples/echo; go build .
-    
+
     - name: Generate app config file
       run: |
         CONFIG=$(cat << EOF
@@ -80,13 +80,13 @@ jobs:
         WEAVER_YAML=$(./cmd/weaver-kube/weaver-kube deploy ${{ env.CONFIG_FILE }})
         echo "Generated YAML file:" $WEAVER_YAML
         echo "WEAVER_YAML=$WEAVER_YAML" >> $GITHUB_ENV
-    
+
     - name: Deploy the application
       run: kubectl apply -f ${{env.WEAVER_YAML}}
 
     - name: Get the name of the echo listener service
       run: |
-        NAME=$(timeout ${{ env.WAIT_TIMEOUT }} /bin/sh -c 'while true; do NAME=$(kubectl get service -l lisName=echo -o jsonpath={.items[].metadata.name}) && echo $NAME && break; sleep 2; done')
+        NAME=$(timeout ${{ env.WAIT_TIMEOUT }} /bin/sh -c 'while true; do NAME=$(kubectl get service -l serviceweaver/listener=echo -o jsonpath={.items[].metadata.name}) && echo $NAME && break; sleep 2; done')
         echo "SERVICE_NAME=$NAME" >> $GITHUB_ENV
 
     - name: Call the echo endpoint until it succeeds
@@ -98,6 +98,6 @@ jobs:
       run: |
         kubectl get all
         kubectl describe pod
-        kubectl logs -l appName=echo
-  
-  
+        kubectl logs -l serviceweaver/app=echo
+
+

--- a/internal/impl/babysitter.go
+++ b/internal/impl/babysitter.go
@@ -223,7 +223,7 @@ func (b *babysitter) watchPods(ctx context.Context, component string) error {
 	// Watch the pods running the requested component.
 	rs := replicaSetName(component, b.cfg.App)
 	name := deploymentName(b.cfg.App.Name, rs, b.cfg.DepId)
-	opts := metav1.ListOptions{LabelSelector: fmt.Sprintf("depName=%s", name)}
+	opts := metav1.ListOptions{LabelSelector: fmt.Sprintf("serviceweaver/name=%s", name)}
 	watcher, err := b.clientset.CoreV1().Pods(b.cfg.Namespace).Watch(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("watch pods for component %s: %w", component, err)

--- a/internal/impl/kube.go
+++ b/internal/impl/kube.go
@@ -556,7 +556,7 @@ func header(app *protos.AppConfig, cfg *KubeConfig, depId, filename string) (str
 #
 # To view a description of every resource, run:
 #
-#     kubectl get all -o custom-columns=KIND:.kind,NAME:.metadata.name,APP:.metadata.labels.appName,VERSION:.metadata.labels.version,DESCRIPTION:.metadata.annotations.description
+#     kubectl get all -o custom-columns=KIND:.kind,NAME:.metadata.name,APP:.metadata.labels.serviceweaver/app,VERSION:.metadata.labels.serviceweaver/version,DESCRIPTION:.metadata.annotations.description
 #
 # To delete the resources, run:
 #

--- a/internal/impl/kube.go
+++ b/internal/impl/kube.go
@@ -209,10 +209,11 @@ func (r *replicaSet) deploymentName() string {
 // calls foo.
 func (r *replicaSet) buildDeployment(cfg *KubeConfig) (*appsv1.Deployment, error) {
 	name := r.deploymentName()
-	matchLabels := map[string]string{"depName": name}
+	matchLabels := map[string]string{"serviceweaver/name": name}
 	podLabels := map[string]string{
-		"appName": r.app.Name,
-		"depName": name,
+		"serviceweaver/name":    name,
+		"serviceweaver/app":     r.app.Name,
+		"serviceweaver/version": r.depId[:8],
 	}
 	if cfg.Observability[metricsConfigKey] != disabled {
 		podLabels["metrics"] = r.app.Name // Needed by Prometheus to scrape the metrics.
@@ -240,7 +241,10 @@ func (r *replicaSet) buildDeployment(cfg *KubeConfig) (*appsv1.Deployment, error
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: r.namespace,
-			Labels:    map[string]string{"version": r.depId[:8]},
+			Labels: map[string]string{
+				"serviceweaver/app":     r.app.Name,
+				"serviceweaver/version": r.depId[:8],
+			},
 			Annotations: map[string]string{
 				"description": fmt.Sprintf("This Deployment hosts components %v.", strings.Join(components, ", ")),
 			},
@@ -296,8 +300,9 @@ func (r *replicaSet) buildListenerService(lis *ReplicaSetConfig_Listener) (*core
 			Name:      lisServiceName,
 			Namespace: r.namespace,
 			Labels: map[string]string{
-				"lisName": lis.Name,
-				"version": r.depId[:8],
+				"serviceweaver/app":      r.app.Name,
+				"serviceweaver/listener": lis.Name,
+				"serviceweaver/version":  r.depId[:8],
 			},
 			Annotations: map[string]string{
 				"description": fmt.Sprintf("This Service forwards traffic to the %q listener.", lis.Name),
@@ -306,7 +311,7 @@ func (r *replicaSet) buildListenerService(lis *ReplicaSetConfig_Listener) (*core
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceType(serviceType),
 			Selector: map[string]string{
-				"depName": r.deploymentName(),
+				"serviceweaver/name": r.deploymentName(),
 			},
 			Ports: []corev1.ServicePort{
 				{
@@ -332,7 +337,10 @@ func (r *replicaSet) buildAutoscaler() (*autoscalingv2.HorizontalPodAutoscaler, 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      aname,
 			Namespace: r.namespace,
-			Labels:    map[string]string{"version": r.depId[:8]},
+			Labels: map[string]string{
+				"serviceweaver/app":     r.app.Name,
+				"serviceweaver/version": r.depId[:8],
+			},
 			Annotations: map[string]string{
 				"description": fmt.Sprintf("This HorizontalPodAutoscaler scales the %q Deployment.", depName),
 			},


### PR DESCRIPTION
This PR improves the labels generated by `weaver kube`. Now, every generated resource has a `serviceweaver/app` and `serviceweaver/version` label.

```console
$ kubectl get all -o custom-columns=KIND:.kind,NAME:.metadata.name,APP:.metadata.labels.serviceweaver/app,VERSION:.metadata.labels.serviceweaver/version,DESCRIPTION:.metadata.annotations.description
KIND                      NAME                                              APP       VERSION    DESCRIPTION
Pod                       collatz-even-ac75eadd-174cc8d6-6cb6f58957-6272p   collatz   ac75eadd   This Pod hosts components collatz.Even, collatz.Odd.
Pod                       weaver-main-ac75eadd-50919913-cbd9f5d77-lflf7     collatz   ac75eadd   This Pod hosts components weaver.Main.
Service                   collatz-ac75eadd                                  collatz   ac75eadd   This Service forwards traffic to the "collatz" listener.
Service                   kubernetes                                        <none>    <none>     <none>
Deployment                collatz-even-ac75eadd-174cc8d6                    collatz   ac75eadd   This Deployment hosts components collatz.Even, collatz.Odd.
Deployment                weaver-main-ac75eadd-50919913                     collatz   ac75eadd   This Deployment hosts components weaver.Main.
ReplicaSet                collatz-even-ac75eadd-174cc8d6-6cb6f58957         collatz   ac75eadd   This Deployment hosts components collatz.Even, collatz.Odd.
ReplicaSet                weaver-main-ac75eadd-50919913-cbd9f5d77           collatz   ac75eadd   This Deployment hosts components weaver.Main.
HorizontalPodAutoscaler   collatz-even-ac75eadd-174cc8d6                    collatz   ac75eadd   This HorizontalPodAutoscaler scales the "collatz-even-ac75eadd-174cc8d6" Deployment.
HorizontalPodAutoscaler   weaver-main-ac75eadd-50919913                     collatz   ac75eadd   This HorizontalPodAutoscaler scales the "weaver-main-ac75eadd-50919913" Deployment.
```