### PR TITLE
Add cpu/mem reqs/limits as knobs.

### DIFF
--- a/cmd/weaver-kube/deploy.go
+++ b/cmd/weaver-kube/deploy.go
@@ -71,7 +71,61 @@ Container Image Names:
 
       - Docker Hub:                docker.io/USERNAME
       - Google Artifact Registry:  LOCATION-docker.pkg.dev/PROJECT-ID
-      - GitHub Container Registry: ghcr.io/NAMESPACE`,
+      - GitHub Container Registry: ghcr.io/NAMESPACE
+
+  You can set more advanced knobs in the "kube" section:
+    a) Namespace - where the application should be deployed.
+       namespace = "your_namespace"
+
+    b) Configure listeners
+      1. Whether your listener should be public, i.e., should it receive ingress
+         traffic from the public internet. If false, the listener is configured
+         only for cluster-internal access. To make a listener "foo" public you
+         should set:
+         listeners.foo = {public = true}
+      2. Whether you want your listener to listen on a particular port:
+         listeners.foo = {port = 1234}
+      3. Whether the listener service should have the same name across multiple
+         application versions:
+         listeners.foo = {service_name = "unique_name"}
+
+      You can specify any combination of the various options or none. E.g.,
+         listeners.foo = {public = true, serice_name = "unique_name"}
+
+    c) Observability - if nothing is specified, the kube deployer will
+       automatically launch Prometheus, Jaeger, Loki and Grafana to retrieve your
+       application's metrics, traces, logs, and to provide custom dashboards.
+
+       If you don't want one or more of these services to run, you can simply
+       disable them. E.g., :
+       [kube.observability]
+       prometheus_service = "none"
+       jaeger_service = "none"
+       loki_service = "none"
+       grafana_service = "none"
+
+       If you want to plugin one or more of your existing Prometheus, Jaeger,
+       Loki, Grafana, you can specify their service name:
+       [kube.observability]
+       prometheus_service = "your_prometheus_service_name"
+       jaeger_service = "your_jaeger_service_name"
+       loki_service = "your_loki_service_name"
+       grafana_service = "your_granfa_service_name"
+
+       Note that we support only the Prometheus, Jaeger, Loki, Grafana stack for
+       observability right now.
+
+    d) Configure resource requirements for the pods [1]. E.g.,
+      [kube.resources]
+      requests_cpu = "200m"
+      requests_mem = "256Mi"
+      limits_cpu = "400m"
+      limits_mem = "512Mi"
+
+      You can also specify any combination of the various options or none.
+
+      [1] https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+`,
 		Flags: flags,
 		Fn:    deploy,
 	}

--- a/internal/impl/kube.go
+++ b/internal/impl/kube.go
@@ -57,17 +57,8 @@ const (
 	internalPort = 10000
 )
 
-var (
-	// Start value for ports used by the public and private listeners.
-	externalPort int32 = 20000
-
-	// Resource allocation units for "cpu" and "memory" resources.
-	//
-	// TODO(rgrandl): Should we allow the user to customize how many
-	// resources each pod starts with?
-	cpuUnit    = resource.MustParse("100m")
-	memoryUnit = resource.MustParse("128Mi")
-)
+// Start value for ports used by the public and private listeners.
+var externalPort int32 = 20000
 
 // replicaSet contains information about a replica set.
 type replicaSet struct {
@@ -96,6 +87,18 @@ type ListenerOptions struct {
 	// is reachable. If zero or not specified, the first available port
 	// is used.
 	Port int32
+}
+
+// resourceRequirements stores the resource requirements configuration for running pods.
+type resourceRequirements struct {
+	// Describes the minimum amount of CPU required to run the pod.
+	RequestsCPU string `toml:"requests_cpu"`
+	// Describes the minimum amount of memory required to run the pod.
+	RequestsMem string `toml:"requests_mem"`
+	// Describes the maximum amount of CPU allowed to run the pod.
+	LimitsCPU string `toml:"limits_cpu"`
+	// Describes the maximum amount of memory allowed to run the pod.
+	LimitsMem string `toml:"limits_mem"`
 }
 
 // KubeConfig stores the configuration information for one execution of a
@@ -174,6 +177,12 @@ type KubeConfig struct {
 	// [3] - https://grafana.com/oss/loki/
 	// [4] - https://grafana.com/
 	Observability map[string]string
+
+	// Resources needed to run the pods. Note that the resources should satisfy
+	// the format specified in [1].
+	//
+	// [1] https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#example-MustParse.
+	Resources resourceRequirements
 }
 
 // shortenComponent shortens the given component name to be of the format
@@ -405,6 +414,11 @@ func (r *replicaSet) buildContainer(cfg *KubeConfig) (corev1.Container, error) {
 		})
 	}
 
+	resources, err := computeResourceRequirements(cfg.Resources)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
 	return corev1.Container{
 		Name:            appContainerName,
 		Image:           r.image,
@@ -413,23 +427,8 @@ func (r *replicaSet) buildContainer(cfg *KubeConfig) (corev1.Container, error) {
 		Env: []corev1.EnvVar{
 			{Name: kubeConfigEnvKey, Value: kubeCfgStr},
 		},
-		Resources: corev1.ResourceRequirements{
-			// NOTE: start with the smallest allowed limits, and count on autoscalers
-			// doing the rest.
-			//
-			// NOTE: if we don't specify the minimum amount of compute resources
-			// required, the autoscaler doesn't work properly, because the metric
-			// server is not able to report the resource usage of the container.
-			Requests: corev1.ResourceList{
-				"memory": memoryUnit,
-				"cpu":    cpuUnit,
-			},
-			// NOTE: we don't specify any limits, allowing all available node
-			// resources to be used, if needed. Note that in practice, we
-			// attach autoscalers to all of our containers, so the extra-usage
-			// should be only for a short period of time.
-		},
-		Ports: ports,
+		Resources: resources,
+		Ports:     ports,
 
 		// Enabling TTY and Stdin allows the user to run a shell inside the container,
 		// for debugging.
@@ -452,7 +451,7 @@ func (r *replicaSet) buildContainer(cfg *KubeConfig) (corev1.Container, error) {
 //     roll out a new application version.
 //
 //     For example, let's assume that we have an app v1 with two replica sets:
-//     `main` and `foo“, with `main` hosting a network listener. When we deploy
+//     `main` and `foo`, with `main` hosting a network listener. When we deploy
 //     v2 of the app, it will be rolled out as follows:
 //
 //     [main v1] [main v1]     [main v1] [main v2]     [main v2] [main v2]
@@ -800,7 +799,7 @@ func buildReplicaSets(app *protos.AppConfig, depId string, image string, cfg *Ku
 	nodes := map[graph.Node]struct{}{}
 	cg.PerNode(func(n graph.Node) {
 		pn := primary[n]
-		nodes[graph.Node(pn)] = struct{}{}
+		nodes[pn] = struct{}{}
 		if replicaSets[pn] == nil {
 			replicaSets[pn] = &replicaSet{
 				name:            components[pn].Name,
@@ -821,6 +820,49 @@ func buildReplicaSets(app *protos.AppConfig, depId string, image string, cfg *Ku
 		edges[graph.Edge{Src: src, Dst: dst}] = struct{}{}
 	})
 	return replicaSets, graph.NewAdjacencyGraph(maps.Keys(nodes), maps.Keys(edges)), nil
+}
+
+// computeResourceRequirements compute the resource requirements to run the application's pods.
+func computeResourceRequirements(req resourceRequirements) (corev1.ResourceRequirements, error) {
+	requests := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
+
+	// Compute the resource requests.
+	if req.RequestsMem != "" {
+		reqsMem, err := resource.ParseQuantity(req.RequestsMem)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("unable to parse requests_mem: %w", err)
+		}
+		requests[corev1.ResourceMemory] = reqsMem
+	}
+	if req.RequestsCPU != "" {
+		reqsCPU, err := resource.ParseQuantity(req.RequestsCPU)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("unable to parse requests_cpu: %w", err)
+		}
+		requests[corev1.ResourceCPU] = reqsCPU
+	}
+
+	// Compute the resource limits.
+	if req.LimitsMem != "" {
+		limitsMem, err := resource.ParseQuantity(req.LimitsMem)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("unable to parse limits_mem: %w", err)
+		}
+		limits[corev1.ResourceMemory] = limitsMem
+	}
+	if req.LimitsCPU != "" {
+		limitsCPU, err := resource.ParseQuantity(req.LimitsCPU)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("unable to parse limits_cpu: %w", err)
+		}
+		limits[corev1.ResourceCPU] = limitsCPU
+	}
+
+	return corev1.ResourceRequirements{
+		Requests: requests,
+		Limits:   limits,
+	}, nil
 }
 
 // readBinary returns the component and listener information embedded in the


### PR DESCRIPTION
Based on the latest Go survey (and interactions with many customers), we've realized that enabling developers to control the resource requirements for the running pods is very important.

This PR enables to control resource requests and resource limits for the kube deployer.

This PR also enhances the `weaver kube deploy help` message to reflect most of the knobs people can control right now when using the kube deployer.