### PR TITLE
Add knob for service account

### DIFF
--- a/cmd/weaver-kube/deploy.go
+++ b/cmd/weaver-kube/deploy.go
@@ -77,6 +77,10 @@ Container Image Names:
     a) Namespace - where the application should be deployed.
        namespace = "your_namespace"
 
+    b) Service account - specify the service account to use when running your
+       application pods.
+       service_account = "your_service_account""
+
     b) Configure listeners
       1. Whether your listener should be public, i.e., should it receive ingress
          traffic from the public internet. If false, the listener is configured
@@ -170,6 +174,10 @@ func deploy(ctx context.Context, args []string) error {
 	if config.Namespace == "" {
 		config.Namespace = "default"
 	}
+	if config.ServiceAccount == "" {
+		config.ServiceAccount = "default"
+	}
+
 	binListeners, err := bin.ReadListeners(app.Binary)
 	if err != nil {
 		return fmt.Errorf("cannot read listeners from binary %s: %w", app.Binary, err)


### PR DESCRIPTION
Right now we allow the user to specify a custom namespace where to deploy a service weaver app using the kube deployer. However, we bound them to run the pods using the default service account.

This PR enables the user to specify a custom service account as well.