### PR TITLE
Refactored deployer code to unexport stuff.

### DIFF
--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -1,0 +1,136 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package impl
+
+// kubeConfig contains configuration for a Service Weaver application deployed
+// with `weaver kube deploy`. The contents of a kubeConfig are parsed from the
+// [kube] section of a weaver.toml file.
+type kubeConfig struct {
+	// Image is the name of the container image hosting the Service Weaver
+	// application.
+	//
+	// If empty, the image name defaults to "<app_name>:<app_version>", where
+	// <app_name> is the name of the app, and <app_version> is the unique
+	// version id of the application deployment.
+	Image string
+
+	// Repo is the name of the repository where the container image is uploaded.
+	//
+	// For example, if Image is "mycontainer:v1" and Repo is
+	// "docker.io/alanturing", then "weaver kube deploy" will build the image
+	// locally as "mycontainer:v1" and then push it to
+	// "docker.io/alanturing/mycontainer:v1".
+	//
+	// If empty, the image is not pushed to a repository.
+	//
+	// Example repositories are:
+	//   - Docker Hub                : docker.io/USERNAME
+	//   - Google Artifact Registry  : LOCATION-docker.pkg.dev/PROJECT-ID
+	//   - GitHub Container Registry : ghcr.io/NAMESPACE
+	Repo string
+
+	// Namespace is the name of the Kubernetes namespace where the application
+	// should be deployed. If not specified, the application will be deployed in
+	// the default namespace.
+	Namespace string
+
+	// If set, it specifies the service account [1] under which to run the pods.
+	// Otherwise, the application is being deployed using the default service
+	// account for your namespace.
+	//
+	// [1] https://kubernetes.io/docs/concepts/security/service-accounts/
+	ServiceAccount string `toml:"service_account"`
+
+	// If true, application listeners will use the underlying nodes' network.
+	// This behavior is generally discouraged, but it may be useful when running
+	// the application in a minikube environment, where using the underlying
+	// nodes' network may make it easier to access the listeners directly from
+	// the host machine.
+	UseHostNetwork bool `toml:"use_host_network"`
+
+	// Options for the application listeners, keyed by listener name.
+	// If a listener isn't specified in the map, default options will be used.
+	Listeners map[string]*listenerConfig
+
+	// Observability controls how the deployer will export observability information
+	// such as logs, metrics and traces, keyed by service. If no options are
+	// specified, the deployer will launch corresponding services for exporting logs,
+	// metrics and traces automatically.
+	//
+	// The key must be one of the following strings:
+	// "prometheus_service" - to export metrics to Prometheus [1]
+	// "jaeger_service"     - to export traces to Jaeger [2]
+	// "loki_service"       - to export logs to Grafana Loki [3]
+	// "grafana_service"    - to visualize/manipulate observability information [4]
+	//
+	// Possible values for each service:
+	// 1) do not specify a value at all; leave it empty
+	// this is the default behavior; kube deployer will automatically create the
+	// observability service for you.
+	//
+	// 2) "none"
+	// kube deployer will not export the corresponding observability information to
+	// any service. E.g., prometheus_service = "none" means that the user will not
+	// be able to see any metrics at all. This can be useful for testing or
+	// benchmarking the performance of your application.
+	//
+	// 3) "your_observability_service_name"
+	// if you already have a running service to collect metrics, traces or logs,
+	// then you can simply specify the service name, and your application will
+	// automatically export the corresponding information to your service. E.g.,
+	// jaeger_service = "jaeger-all-in-one" will enable your running Jaeger
+	// "service/jaeger-all-in-one" to capture all the app traces.
+	//
+	// [1] - https://prometheus.io/
+	// [2] - https://www.jaegertracing.io/
+	// [3] - https://grafana.com/oss/loki/
+	// [4] - https://grafana.com/
+	Observability map[string]string
+
+	// Resources needed to run the pods. Note that the resources should satisfy
+	// the format specified in [1].
+	//
+	// [1] https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#example-MustParse.
+	Resources resourceRequirements
+}
+
+// listenerConfig stores configuration options for a listener.
+type listenerConfig struct {
+	// If specified, the listener service will have the name set to this value.
+	// Otherwise, we will generate a unique name for each app version.
+	ServiceName string `toml:"service_name"`
+
+	// Is the listener public, i.e., should it receive ingress traffic
+	// from the public internet. If false, the listener is configured only
+	// for cluster-internal access.
+	Public bool
+
+	// If specified, the port inside the container on which the listener
+	// is reachable. If zero or not specified, the first available port
+	// is used.
+	Port int32
+}
+
+// resourceRequirements stores the resource requirements configuration for running pods.
+type resourceRequirements struct {
+	// Describes the minimum amount of CPU required to run the pod.
+	RequestsCPU string `toml:"requests_cpu"`
+	// Describes the minimum amount of memory required to run the pod.
+	RequestsMem string `toml:"requests_mem"`
+	// Describes the maximum amount of CPU allowed to run the pod.
+	LimitsCPU string `toml:"limits_cpu"`
+	// Describes the maximum amount of memory allowed to run the pod.
+	LimitsMem string `toml:"limits_mem"`
+}

--- a/internal/impl/deploy.go
+++ b/internal/impl/deploy.go
@@ -1,0 +1,140 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package impl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ServiceWeaver/weaver/runtime"
+	"github.com/ServiceWeaver/weaver/runtime/bin"
+	"github.com/ServiceWeaver/weaver/runtime/codegen"
+	"github.com/ServiceWeaver/weaver/runtime/version"
+	"github.com/google/uuid"
+)
+
+// Deploy generates a Kubernetes YAML file and corresponding Docker image to
+// deploy the Service Weaver application specified by the provided weaver.toml
+// config file.
+func Deploy(ctx context.Context, configFilename string) error {
+	// Read the config file.
+	contents, err := os.ReadFile(configFilename)
+	if err != nil {
+		return fmt.Errorf("read config file %q: %w", configFilename, err)
+	}
+
+	// Parse and validate the app config.
+	app, err := runtime.ParseConfig(configFilename, string(contents), codegen.ComponentConfigValidator)
+	if err != nil {
+		return fmt.Errorf("parse config file %q: %w", configFilename, err)
+	}
+	if _, err := os.Stat(app.Binary); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("binary %q doesn't exist", app.Binary)
+	}
+	if err := checkVersionCompatibility(app.Binary); err != nil {
+		return err
+	}
+
+	// Parse and validate the [kube] section of the app config.
+	config := &kubeConfig{}
+	if err := runtime.ParseConfigSection("kube", "github.com/ServiceWeaver/weaver/kube", app.Sections, config); err != nil {
+		return fmt.Errorf("parse [kube] section of config: %w", err)
+	}
+	if config.Repo == "" {
+		fmt.Fprintln(os.Stderr, "No container repo specified in the config file. The container image will only be accessible locally. See `weaver kube deploy --help` for details.")
+	}
+	if config.Namespace == "" {
+		config.Namespace = "default"
+	}
+	if config.ServiceAccount == "" {
+		config.ServiceAccount = "default"
+	}
+	binListeners, err := bin.ReadListeners(app.Binary)
+	if err != nil {
+		return fmt.Errorf("cannot read listeners from binary %s: %w", app.Binary, err)
+	}
+	allListeners := make(map[string]struct{})
+	for _, c := range binListeners {
+		for _, l := range c.Listeners {
+			allListeners[l] = struct{}{}
+		}
+	}
+	for lis := range config.Listeners {
+		if _, ok := allListeners[lis]; !ok {
+			return fmt.Errorf("listener %s specified in the config not found in the binary", lis)
+		}
+	}
+
+	// Unique app deployment identifier.
+	depId := uuid.New().String()
+
+	// Build the docker image for the deployment.
+	image, err := buildAndUploadDockerImage(ctx, app, depId, config.Image, config.Repo)
+	if err != nil {
+		return err
+	}
+
+	// Generate the kube deployment information.
+	return generateYAMLs(image, app, depId, config)
+}
+
+// checkVersionCompatibility checks that the `weaver kube` binary is compatible
+// with the application binary being deployed.
+func checkVersionCompatibility(appBinary string) error {
+	versions, err := bin.ReadVersions(appBinary)
+	if err != nil {
+		return fmt.Errorf("read versions: %w", err)
+	}
+	selfVersion, _, err := ToolVersion()
+	if err != nil {
+		return fmt.Errorf("read weaver-kube version: %w", err)
+	}
+
+	// Try to relativize the binary, defaulting to the absolute path if there
+	// are any errors..
+	relativize := func(bin string) string {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return bin
+		}
+		rel, err := filepath.Rel(cwd, bin)
+		if err != nil {
+			return bin
+		}
+		return rel
+	}
+
+	if versions.DeployerVersion != version.DeployerVersion {
+		return fmt.Errorf(`
+	ERROR: The binary you're trying to deploy (%q) was built with
+	github.com/ServiceWeaver/weaver module version %s. However, the 'weaver-kube'
+	binary you're using was built with weaver module version %s. These versions are
+	incompatible.
+
+	We recommend updating both the weaver module your application is built with and
+	updating the 'weaver-kube' command by running the following.
+
+		go get github.com/ServiceWeaver/weaver@latest
+		go install github.com/ServiceWeaver/weaver-kube/cmd/weaver-kube@latest
+
+	Then, re-build your code and re-run 'weaver-kube deploy'. If the problem
+	persists, please file an issue at https://github.com/ServiceWeaver/weaver/issues`,
+			relativize(appBinary), versions.ModuleVersion, selfVersion)
+	}
+	return nil
+}

--- a/internal/impl/docker.go
+++ b/internal/impl/docker.go
@@ -56,10 +56,10 @@ type buildSpec struct {
 	goInstall []string // binary targets that should be 'go install'-ed
 }
 
-// BuildAndUploadDockerImage builds a docker image and uploads it to a remote
+// buildAndUploadDockerImage builds a docker image and uploads it to a remote
 // repo, if one is specified. It returns the image name that should be used in
 // Kubernetes YAML files.
-func BuildAndUploadDockerImage(ctx context.Context, app *protos.AppConfig, depId string,
+func buildAndUploadDockerImage(ctx context.Context, app *protos.AppConfig, depId string,
 	image, repo string) (string, error) {
 	// Create the build specifications.
 	spec, err := dockerBuildSpec(app, depId, image)

--- a/internal/impl/observability.go
+++ b/internal/impl/observability.go
@@ -151,7 +151,7 @@ var dashboardContent string
 
 // generateObservabilityYAMLs generates Kubernetes YAMLs for exporting
 // applications' metrics, logs, and traces.
-func generateObservabilityYAMLs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generateObservabilityYAMLs(appName string, cfg *kubeConfig) ([]byte, error) {
 	configs, err := generateConfigsToExportTraces(appName, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create kube configs to export traces: %w", err)
@@ -208,7 +208,7 @@ func generateObservabilityYAMLs(appName string, cfg *KubeConfig) ([]byte, error)
 // observability = {jaeger_service = "jaeger-all-in-one"}
 //
 // [1] https://helm.sh/
-func generateConfigsToExportTraces(appName string, cfg *KubeConfig) ([]byte, error) {
+func generateConfigsToExportTraces(appName string, cfg *kubeConfig) ([]byte, error) {
 	// The user disabled exporting the traces, don't generate anything.
 	if cfg.Observability[tracesConfigKey] != auto {
 		return nil, nil
@@ -354,7 +354,7 @@ func generateConfigsToExportTraces(appName string, cfg *KubeConfig) ([]byte, err
 // observability = {prometheus_service = "prometheus-server"}
 //
 // [1] https://helm.sh/
-func generateConfigsToExportMetrics(appName string, cfg *KubeConfig) ([]byte, error) {
+func generateConfigsToExportMetrics(appName string, cfg *kubeConfig) ([]byte, error) {
 	// The user disabled exporting the metrics, don't generate anything.
 	if cfg.Observability[metricsConfigKey] == disabled {
 		return nil, nil
@@ -389,7 +389,7 @@ func generateConfigsToExportMetrics(appName string, cfg *KubeConfig) ([]byte, er
 //
 // Note that these configs are needed by both the automatically started Prometheus
 // service and the one started by the user.
-func generatePrometheusConfigs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generatePrometheusConfigs(appName string, cfg *kubeConfig) ([]byte, error) {
 	cname := name{appName, "prometheus", "config"}.DNSLabel()
 	pname := name{appName, "prometheus"}.DNSLabel()
 
@@ -452,7 +452,7 @@ scrape_configs:
 //
 // TODO(rgrandl): We run a single instance of Prometheus for now. We might want
 // to scale it up if it becomes a bottleneck.
-func generatePrometheusServiceConfigs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generatePrometheusServiceConfigs(appName string, cfg *kubeConfig) ([]byte, error) {
 	cname := name{appName, "prometheus", "config"}.DNSLabel()
 	pname := name{appName, "prometheus"}.DNSLabel()
 
@@ -630,7 +630,7 @@ func generatePrometheusServiceConfigs(appName string, cfg *KubeConfig) ([]byte, 
 //	it will automatically add your Loki service as a datasource.
 //
 // [1] https://helm.sh/
-func generateConfigsToExportLogs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generateConfigsToExportLogs(appName string, cfg *kubeConfig) ([]byte, error) {
 	// The user disabled exporting the logs, don't generate anything.
 	if cfg.Observability[logsConfigKey] == disabled {
 		return nil, nil
@@ -679,7 +679,7 @@ func generateConfigsToExportLogs(appName string, cfg *KubeConfig) ([]byte, error
 // service and the one started by the user.
 //
 // TODO(rgrandl): check if we can simplify the configurations.
-func generateLokiConfigs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generateLokiConfigs(appName string, cfg *kubeConfig) ([]byte, error) {
 	cname := name{appName, "loki", "config"}.DNSLabel()
 	lname := name{appName, "loki"}.DNSLabel()
 
@@ -760,7 +760,7 @@ schema_config:
 // agent and the one started by the user.
 //
 // TODO(rgrandl): check if we can simplify the configurations.
-func generatePromtailConfigs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generatePromtailConfigs(appName string, cfg *kubeConfig) ([]byte, error) {
 	promName := name{appName, "promtail"}.DNSLabel()
 
 	var lokiURL string
@@ -859,7 +859,7 @@ scrape_configs:
 //
 // TODO(rgrandl): We run a single instance of Loki for now. We might want to
 // scale it up if it becomes a bottleneck.
-func generateLokiServiceConfigs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generateLokiServiceConfigs(appName string, cfg *kubeConfig) ([]byte, error) {
 	// Build the kubernetes Loki deployment.
 	cname := name{appName, "loki", "config"}.DNSLabel()
 	lname := name{appName, "loki"}.DNSLabel()
@@ -976,7 +976,7 @@ func generateLokiServiceConfigs(appName string, cfg *KubeConfig) ([]byte, error)
 //
 // Note that the configs should be generated iff the kube deployer automatically
 // runs Promtail along with the app.
-func generatePromtailAgentConfigs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generatePromtailAgentConfigs(appName string, cfg *kubeConfig) ([]byte, error) {
 	// Create a Promtail daemonset that will run on each node. The daemonset will
 	// run in order to scrape the pods running on each node.
 	promName := name{appName, "promtail"}.DNSLabel()
@@ -1141,7 +1141,7 @@ func generatePromtailAgentConfigs(appName string, cfg *KubeConfig) ([]byte, erro
 // the configured datasources.
 //
 // [1] https://helm.sh/
-func generateConfigsToExportToGrafana(appName string, cfg *KubeConfig) ([]byte, error) {
+func generateConfigsToExportToGrafana(appName string, cfg *kubeConfig) ([]byte, error) {
 	// The user disabled Grafana, don't generate anything.
 	if cfg.Observability[grafanaConfigKey] == disabled {
 		return nil, nil
@@ -1175,7 +1175,7 @@ func generateConfigsToExportToGrafana(appName string, cfg *KubeConfig) ([]byte, 
 // to manipulate various datasources and to export dashboards.
 //
 // TODO(rgrandl): check if we can simplify the configurations.
-func generateGrafanaConfigs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generateGrafanaConfigs(appName string, cfg *kubeConfig) ([]byte, error) {
 	cname := name{appName, "grafana", "config"}.DNSLabel()
 
 	// Build the config map that holds the Grafana configuration file. In the
@@ -1316,7 +1316,7 @@ providers:
 //
 // TODO(rgrandl): We run a single instance of Grafana for now. We might want
 // to scale it up if it becomes a bottleneck.
-func generateGrafanaServiceConfigs(appName string, cfg *KubeConfig) ([]byte, error) {
+func generateGrafanaServiceConfigs(appName string, cfg *kubeConfig) ([]byte, error) {
 	cname := name{appName, "grafana", "config"}.DNSLabel()
 	gname := name{appName, "grafana"}.DNSLabel()
 


### PR DESCRIPTION
Previously, `impl.KubeConfig`, `impl.BuildAndUploadDockerImage`, and `impl.GenerateYAMLs` were all exported and used by `cmd/weaver-kube/deploy.go`. This PR moves the `deploy.go` code into `internal/impl/deploy.go` to unexport these things, and instead exports a single `Deploy` function.

I also moved all user-provided config into a `config.go` file.