### PR TITLE
Add options to configure probes

### DIFF
--- a/cmd/weaver-kube/deploy.go
+++ b/cmd/weaver-kube/deploy.go
@@ -116,6 +116,24 @@ Container Image Names:
       You can also specify any combination of the various options or none.
 
       [1] https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+    e) Configure probes [1]. The kube deployer allows you to configure readiness
+       and liveness probes. For each probe, you can configure:
+         - how often to perform the probe "period_secs"
+         - how long to wait for a probe to respond before declaring a timeout "timeout_secs"
+         - minimum consecutive successes for the probe to be successful "success_threshold"
+         - minimum consecutive failures for the probe to be considered failed "failure_threshold"
+         - a probe handler that describes the probe behavior. You can use a TCP,
+           HTTP or a custom commands probe handler.
+
+       E.g.,
+       [kube.readiness_probe]
+       period_secs = 2
+       [kube.readiness_probe.http]
+       path = "/health"
+       port = 8081
+
+      [1] https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 `,
 		Flags: flags,
 		Fn: func(ctx context.Context, args []string) error {


### PR DESCRIPTION
In kubernetes probes are used to determine when to restart a container, to know when a container is ready to start accepting traffic, or to know when when a container application has started.

There are 3 types of probes: liveness, readiness and startup probes. Among there liveness and readiness are the most common and also the ones required by the users in the Go survey.

This PR adds support to specify the liveness and readiness probes in the weaver kube deployer. The knobs exposed to the user are not that many: 1) Knobs that define things like:
- how often to probe (optional)
- how many seconds to wait for an answer before declaring the probe failing (optional)
- how many consecutive successful probes to declare the container as healthy (optional)
- how many consecutive failed probes to declare the container as unhealthy (optional)

2) Define what the probe should do
- should you use HTTP for probing? If so, you can specify the port and a path to check for probing (port is mandatory, path is optional)
- should you use TCP for probing? If so, you can specify the port
- should you use a custom list of commands?

We took the minimum number of knobs that might make sense for the user to configure probes. I think it should cover most of the usecases and scenarios someone might run into.