### PR TITLE
Added basic plugin system to customize telemetry.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ServiceWeaver/weaver v0.22.1-0.20231019162801-c2294d1ae0e8
 	github.com/google/uuid v1.3.1
 	go.opentelemetry.io/otel v1.19.0
+	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/trace v1.19.0
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/sync v0.4.0
@@ -52,7 +53,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.16.0 // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect

--- a/internal/tool/babysitter.go
+++ b/internal/tool/babysitter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package tool
 
 import (
 	"context"
@@ -30,42 +30,42 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 )
 
-var babysitterFlags = flag.NewFlagSet("babysitter", flag.ContinueOnError)
-
-var babysitterCmd = tool.Command{
-	Name:        "babysitter",
-	Flags:       babysitterFlags,
-	Description: "The weaver kubernetes babysitter",
-	Help: `Usage:
+func babysitterCmd(opts impl.BabysitterOptions) *tool.Command {
+	return &tool.Command{
+		Name:        "babysitter",
+		Flags:       flag.NewFlagSet("babysitter", flag.ContinueOnError),
+		Description: "The weaver kubernetes babysitter",
+		Help: `Usage:
   weaver kube babysitter <weaver config file> <babysitter config file> <component>...
 
 Flags:
   -h, --help   Print this help message.`,
-	Fn: func(ctx context.Context, args []string) error {
-		// Parse command line arguments.
-		if len(args) < 3 {
-			return fmt.Errorf("want >= 3 arguments, got %d", len(args))
-		}
-		app, err := parseWeaverConfig(args[0])
-		if err != nil {
-			return err
-		}
-		config, err := parseBabysitterConfig(args[1])
-		if err != nil {
-			return err
-		}
-		components := args[2:]
+		Fn: func(ctx context.Context, args []string) error {
+			// Parse command line arguments.
+			if len(args) < 3 {
+				return fmt.Errorf("want >= 3 arguments, got %d", len(args))
+			}
+			app, err := parseWeaverConfig(args[0])
+			if err != nil {
+				return err
+			}
+			config, err := parseBabysitterConfig(args[1])
+			if err != nil {
+				return err
+			}
+			components := args[2:]
 
-		// Create the babysitter.
-		b, err := impl.NewBabysitter(ctx, app, config, components)
-		if err != nil {
-			return err
-		}
+			// Create the babysitter.
+			b, err := impl.NewBabysitter(ctx, app, config, components, opts)
+			if err != nil {
+				return err
+			}
 
-		// Run the babysitter.
-		return b.Serve()
-	},
-	Hidden: true,
+			// Run the babysitter.
+			return b.Serve()
+		},
+		Hidden: true,
+	}
 }
 
 // parseWeaverConfig parses a weaver.toml config file.

--- a/internal/tool/deploy.go
+++ b/internal/tool/deploy.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package tool
 
 import (
 	"context"
@@ -94,7 +94,7 @@ Container Image Names:
 
       [1] https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
-    e) Configure probes [1]. The kube deployer allows you to configure readiness
+    d) Configure probes [1]. The kube deployer allows you to configure readiness
        and liveness probes. For each probe, you can configure:
          - how often to perform the probe "period_secs"
          - how long to wait for a probe to respond before declaring a timeout "timeout_secs"

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -19,6 +19,8 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
+// Commands returns the set of `weaver kube` commands, which can be run via
+// tool.Run.
 func Commands(opts impl.BabysitterOptions) map[string]*tool.Command {
 	return map[string]*tool.Command{
 		"version": &versionCmd,

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,29 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package tool
 
 import (
-	"context"
-	"flag"
-	"fmt"
-	"runtime"
-
 	"github.com/ServiceWeaver/weaver-kube/internal/impl"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
-var versionCmd = tool.Command{
-	Name:        "version",
-	Flags:       flag.NewFlagSet("version", flag.ContinueOnError),
-	Description: "Show weaver kube version",
-	Help:        "Usage:\n  weaver kube version",
-	Fn: func(context.Context, []string) error {
-		version, _, err := impl.ToolVersion()
-		if err != nil {
-			return err
-		}
-		fmt.Printf("weaver kube %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
-		return nil
-	},
+func Commands(opts impl.BabysitterOptions) map[string]*tool.Command {
+	return map[string]*tool.Command{
+		"version": &versionCmd,
+		"deploy":  &deployCmd,
+
+		// Hidden commands.
+		"babysitter": babysitterCmd(opts),
+	}
 }

--- a/internal/tool/version.go
+++ b/internal/tool/version.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,14 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package tool
 
 import (
+	"context"
+	"flag"
+	"fmt"
+	"runtime"
+
 	"github.com/ServiceWeaver/weaver-kube/internal/impl"
-	"github.com/ServiceWeaver/weaver-kube/internal/tool"
-	swtool "github.com/ServiceWeaver/weaver/runtime/tool"
+	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
-func main() {
-	swtool.Run("weaver kube", tool.Commands(impl.BabysitterOptions{}))
+var versionCmd = tool.Command{
+	Name:        "version",
+	Flags:       flag.NewFlagSet("version", flag.ContinueOnError),
+	Description: "Show weaver kube version",
+	Help:        "Usage:\n  weaver kube version",
+	Fn: func(context.Context, []string) error {
+		version, _, err := impl.ToolVersion()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("weaver kube %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
+		return nil
+	},
 }

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -1,0 +1,47 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"context"
+
+	"github.com/ServiceWeaver/weaver-kube/internal/impl"
+	"github.com/ServiceWeaver/weaver-kube/internal/tool"
+	"github.com/ServiceWeaver/weaver/runtime/metrics"
+	"github.com/ServiceWeaver/weaver/runtime/protos"
+	swtool "github.com/ServiceWeaver/weaver/runtime/tool"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Plugins configure a Service Weaver application deployed on Kubernetes.
+//
+// Note that the handlers inside a Plugins struct are invoked on every replica
+// of a Service Weaver application binary on locally produced logs, metrics,
+// and traces. Handlers may be called concurrently from multiple goroutines.
+type Plugins struct {
+	// HandleLogEntry handles log entries produced by a component logger.
+	HandleLogEntry func(context.Context, *protos.LogEntry) error
+	// HandleTraceSpans handles spans produced by inter-component communication.
+	HandleTraceSpans func(context.Context, []trace.ReadOnlySpan) error
+	// HandleMetrics is called periodically on a snapshot of all metric values.
+	HandleMetrics func(context.Context, []*metrics.MetricSnapshot) error
+}
+
+// Run runs the "weaver-kube" binary. You can provide Run a set of Plugins to
+// customize the behavior of "weaver-kube". The provided name is the name of
+// the custom binary.
+func Run(name string, plugins Plugins) {
+	swtool.Run(name, tool.Commands(impl.BabysitterOptions(plugins)))
+}


### PR DESCRIPTION
This PR introduces a very basic plugin system that allows developers to customize how `weaver-kube` manages logs, metrics, and traces. For example, consider the following `foo/main.go`:

```
// This is file foo/main.go.
package main

import ...

func main() {
    plugins := tool.Plugins{
        HandleLogEntry: func(context.Context, *protos.LogEntry) error {
            ...
        },
        HandleTraceSpans: func(context.Context, []trace.ReadOnlySpan) error {
            ...
        },
        HandleMetrics: func(context.Context, []*metrics.MetricSnapshot) error {
            ...
        },
    }
    tool.Run("foo", plugins)
}
```

We can build this file into an executable `foo` that behaves the same as `weaver-kube`, but uses the provided plugins:

```shell
$ foo --help
Deploy and manage Service Weaver programs.

Usage:
  foo <command> ...

Available Commands:
  deploy       Deploy a Service Weaver app
  help         Print help for a sub-command
  version      Show foo version

Flags:
  -h, --help   Print this help message.

Use "foo help <command>" for more information about a command.
```

See https://github.com/mwhittaker/jeagar for a complete example.

In the long term, we'll replace this basic plugin mechanism with something more general. This PR allows customers to onboard to Service Weaver in the short term.