### PR TITLE
Add pod anti affinity rule by default

### DIFF
--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -83,6 +83,12 @@ type kubeConfig struct {
 	// [1] https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/autoscaling#HorizontalPodAutoscalerSpec.
 	ScalingSpec *autoscalingv2.HorizontalPodAutoscalerSpec
 
+	// Specs for pod affinity. Note that the affinity specs should satisfy
+	// the format specified in [1].
+	//
+	// [1] https://pkg.go.dev/k8s.io/api/core/v1#Affinity
+	AffinitySpec *corev1.Affinity
+
 	// Volumes that should be provided to all the running components.
 	StorageSpec volumeSpecs
 


### PR DESCRIPTION
Right now, the Kubernetes scheduler can deploy replicas of the same service on the same node. This is not desirable for HA. Also, it is impossible for the user to specify any kind of affinity rules for the pods.

This PR adds the ability to configure an affinity spec in the config. Also, it adds by default an anti-affinity rule to make sure that the Kubernetes scheduler is doing its best to schedule different replicas for a service to different nodes.