### PR TITLE
kube: prefix `Role` and `RoleBinding` with `serviceweaver`

### DIFF
--- a/examples/telemetry/prometheus.yaml
+++ b/examples/telemetry/prometheus.yaml
@@ -89,7 +89,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: pods-getter
+  name: serviceweaver-pods-getter
   namespace: default
 rules:
 - apiGroups:
@@ -107,12 +107,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
-  name: default-pods-getter
+  name: serviceweaver-default-pods-getter
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pods-getter
+  name: serviceweaver-pods-getter
 subjects:
 - kind: ServiceAccount
   name: default

--- a/internal/impl/kube.go
+++ b/internal/impl/kube.go
@@ -507,7 +507,7 @@ func generateRolesAndBindings(w io.Writer, namespace, serviceAccount string) err
 			Kind:       "Role",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pods-getter",
+			Name:      "serviceweaver-pods-getter",
 			Namespace: namespace,
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -525,13 +525,13 @@ func generateRolesAndBindings(w io.Writer, namespace, serviceAccount string) err
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default-pods-getter",
+			Name:      "serviceweaver-default-pods-getter",
 			Namespace: namespace,
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     "pods-getter",
+			Name:     "serviceweaver-pods-getter",
 		},
 		Subjects: []rbacv1.Subject{
 			{


### PR DESCRIPTION
As of now there are no labels and annotations added to the `Roles` and `RoleBinding` created by service-weaver making it difficult for admins to figure out what and why this role was created so add a `serviceweaver-` prefix.

Naming convention of default of Roles and Rolebindings do have prefix associated to them, for example

```console
NAMESPACE     NAME                                                ROLE                                                  AGE
kube-public   kubeadm:bootstrap-signer-clusterinfo                Role/kubeadm:bootstrap-signer-clusterinfo             17m
kube-public   system:controller:bootstrap-signer                  Role/system:controller:bootstrap-signer               17m
kube-system   kube-proxy                                          Role/kube-proxy                                       17m
kube-system   kubeadm:kubelet-config                              Role/kubeadm:kubelet-config                           17m
kube-system   kubeadm:nodes-kubeadm-config                        Role/kubeadm:nodes-kubeadm-config                     17m
kube-system   system::extension-apiserver-authentication-reader   Role/extension-apiserver-authentication-reader        17m
kube-system   system::leader-locking-kube-controller-manager      Role/system::leader-locking-kube-controller-manager   17m
kube-system   system::leader-locking-kube-scheduler               Role/system::leader-locking-kube-scheduler            17m
kube-system   system:controller:bootstrap-signer                  Role/system:controller:bootstrap-signer               17m
kube-system   system:controller:cloud-provider                    Role/system:controller:cloud-provider                 17m
kube-system   system:controller:token-cleaner                     Role/system:controller:token-cleaner                  17m
```