### PR TITLE
build, push: add support for `podman`

### DIFF
--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -38,6 +38,12 @@ type kubeConfig struct {
 	// version id of the application deployment.
 	Image string
 
+	// Build tool is the name of the container build tool to use.
+	//
+	// If empty, Service Weaver will pick default build tool as `docker`.
+	// Supported values are `docker` and `podman`.
+	BuildTool string
+
 	// Repo is the name of the repository where the container image is uploaded.
 	//
 	// For example, if Image is "mycontainer:v1" and Repo is


### PR DESCRIPTION
Serviceweaver as of now supports `docker` as the default `build` and `push` tool following PR adds support for `podman` since `podman`'s CLI is directly compatible with `docker` and supports both `rootless` and `rootful` for **build and push**.