### PR TITLE
Add app name to pods/services names

### DIFF
--- a/internal/impl/kube.go
+++ b/internal/impl/kube.go
@@ -866,5 +866,5 @@ func shortenComponent(component string) string {
 func deploymentName(app, component, deploymentId string) string {
 	hash := hash8([]string{app, component, deploymentId})
 	shortened := strings.ToLower(shortenComponent(component))
-	return fmt.Sprintf("%s-%s-%s", shortened, deploymentId[:8], hash)
+	return fmt.Sprintf("%s-%s-%s-%s", app, shortened, deploymentId[:8], hash)
 }


### PR DESCRIPTION
Right now, the user has to filter based on labels to see which pods are from which app.

This PR adds the app name to the names of the pods and services. While the names will become slightly longer, it makes it easier for users to see which resources are from each app w/o filtering based on labels. Also, this is consistent with what we do in the GKE deployer, where the app name is also part of the resource names.